### PR TITLE
chore: standardize robots.txt for SEO crawl budget optimization

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,7 +1,51 @@
-User-agent: *
-Disallow: /
+# =============================================================
+# Deco Commerce — robots.txt (Deco Universal)
+# Platform-agnostic rules for all Deco storefronts.
+# =============================================================
 
-User-agent: Googlebot
+User-agent: *
+
+# --- Deco framework internals ---
+Disallow: /deco/render
+Disallow: /live/invoke
+Disallow: /live/invoke/
+
+# --- Backend API proxies ---
+Disallow: /api/
+Disallow: /no-cache/
+Disallow: /proxy/
+Disallow: /graphql/
+
+# --- Authentication / checkout / account ---
+Disallow: /checkout
+Disallow: /checkout/
+Disallow: /login
+Disallow: /login/
+Disallow: /account
+Disallow: /account/
+Disallow: /_secure/
+Disallow: /admin/
+
+# --- Tracking / click ID params (duplicate content) ---
+Disallow: /*?utm_source=
+Disallow: /*?utm_medium=
+Disallow: /*?utm_campaign=
+Disallow: /*?utm_content=
+Disallow: /*?utm_term=
+Disallow: /*?utmi_cp=
+Disallow: /*?utmi_p=
+Disallow: /*?utmi_pc=
+Disallow: /*?gclid=
+Disallow: /*?fbclid=
+Disallow: /*?srsltid=
+Disallow: /*?gbraid=
+Disallow: /*?wbraid=
+Disallow: /*?msclkid=
+Disallow: /*?li_fat_id=
+
+# --- Cloudflare infra ---
+Disallow: /cdn-cgi/
+
 Allow: /
 
 Sitemap: https://www.wedigi.com.br/sitemap.xml


### PR DESCRIPTION
## What

Standardized `robots.txt` to optimize SEO crawl budget.

Based on a Cloudflare bot traffic audit (30 days, 118M bot requests across decocdn.com + deco.site), we found that 40%+ of bot crawl budget is wasted on internal framework endpoints, backend APIs, filter explosion URLs, and tracking parameters.

## Blocked

**Deco framework:**
- `/live/invoke` — server function endpoint (returns empty JSON on GET)
- `/api/`, `/no-cache/`, `/proxy/`, `/graphql/` — backend API proxies

**Tracking params (duplicate content):**
- UTM params, Google/Facebook/Bing/LinkedIn click IDs (`gclid`, `fbclid`, `srsltid`, etc.)

## NOT blocked

- Product pages, category pages, content pages — fully crawlable
- `/_frsh/js/*` — needed for Google Web Rendering Service
- `/deco/render` — partial section renderer, needed for page rendering quality
- Sitemap — preserved from existing robots.txt

## References

- [Cloudflare Bot Crawl Audit](https://github.com/deco-cx/stats-lake/blob/main/bot-crawl-audit-2026-03-26.md)